### PR TITLE
33 introspection

### DIFF
--- a/django_graph_api/graphql/schema.py
+++ b/django_graph_api/graphql/schema.py
@@ -63,6 +63,8 @@ class SchemaObject(Object):
                     continue
                 types.add(new_object_type)
                 self._collect_types(new_object_type, types)
+            elif field.type_:
+                types.add(field.type_)
         return types
 
     def get_types(self):

--- a/django_graph_api/graphql/schema.py
+++ b/django_graph_api/graphql/schema.py
@@ -41,7 +41,11 @@ class TypeObject(Object):
     def get_fields(self):
         if self.data.kind != OBJECT:
             return None
-        return self.data._declared_fields.items()
+        # return self.data._declared_fields.items()
+        return sorted(
+            self.data._declared_fields.items(),
+            key=lambda item: item[0],
+        )
 
 
 class SchemaObject(Object):
@@ -67,8 +71,17 @@ class SchemaObject(Object):
                 types.add(field.type_)
         return types
 
+    def _type_key(self, type_):
+        object_name = getattr(type_, 'object_name', type_.__name__)
+        return (
+            object_name.startswith('__'),
+            type_.kind,
+            object_name,
+        )
+
     def get_types(self):
-        return list(self._collect_types(self.data))
+        types = self._collect_types(self.data)
+        return sorted(types, key=self._type_key)
 
     def get_queryType(self):
         return self.data

--- a/django_graph_api/graphql/schema.py
+++ b/django_graph_api/graphql/schema.py
@@ -1,4 +1,78 @@
+import copy
+
 from graphql.parser import GraphQLParser
+from django_graph_api.graphql.types import (
+    CharField,
+    ManyRelatedField,
+    Object,
+    OBJECT,
+    RelatedField,
+)
+
+
+class FieldObject(Object):
+    # self.data will be an item from a declared fields dict
+    object_name = '__Field'
+    name = CharField()
+    description = CharField()
+    type = RelatedField(lambda: TypeObject)
+
+    def get_name(self):
+        return self.data[0]
+
+    def get_description(self):
+        return getattr(self.data[1], 'description', None)
+
+    def get_type(self):
+        return self.data[1].type_
+
+
+class TypeObject(Object):
+    # self.data will be an object or scalar
+    object_name = '__Type'
+    kind = CharField()
+    name = CharField()
+    description = CharField()
+    fields = ManyRelatedField(FieldObject)
+
+    def get_name(self):
+        return getattr(self.data, 'object_name', self.data.__name__)
+
+    def get_fields(self):
+        if self.data.kind != OBJECT:
+            return None
+        return self.data._declared_fields.items()
+
+
+class SchemaObject(Object):
+    # self.data will be the query_root.
+    object_name = '__Schema'
+    types = ManyRelatedField(TypeObject)
+    queryType = RelatedField(TypeObject)
+    mutationType = RelatedField(TypeObject)
+
+    def _collect_types(self, object_type, types=None):
+        if types is None:
+            types = set()
+        for field in object_type._declared_fields.values():
+            if isinstance(field, RelatedField):
+                new_object_type = field.resolve_object_type(field.object_type)
+                if new_object_type == 'self':
+                    continue
+                if new_object_type in types:
+                    continue
+                types.add(new_object_type)
+                self._collect_types(new_object_type, types)
+        return types
+
+    def get_types(self):
+        return list(self._collect_types(self.data))
+
+    def get_queryType(self):
+        return self.data
+
+    def get_mutationType(self):
+        return None
 
 
 class Schema(object):
@@ -30,9 +104,15 @@ class Schema(object):
     def __init__(self):
         self.query_root = None
 
-    def register_query_root(self, query_root):
-        self.query_root = query_root
-        return query_root
+    def register_query_root(self, BaseQueryRoot):
+        class QueryRoot(BaseQueryRoot):
+            def get___schema(self):
+                return self.__class__
+        QueryRoot._declared_fields = copy.deepcopy(BaseQueryRoot._declared_fields)
+        QueryRoot._declared_fields['__schema'] = RelatedField(SchemaObject)
+
+        self.query_root = QueryRoot
+        return QueryRoot
 
     def execute(self, document):
         """
@@ -70,9 +150,6 @@ class Schema(object):
         ast = parser.parse(document)
 
         query_ast = ast.definitions[0]
-
-        if any(selection.name == '__schema' for selection in query_ast.selections):
-            raise NotImplementedError('This version of django-graph-api does not support introspection')
 
         return {
             'data': self.query_root(query_ast, None).serialize(),

--- a/django_graph_api/graphql/types.py
+++ b/django_graph_api/graphql/types.py
@@ -248,12 +248,17 @@ class RelatedField(Field):
     def __init__(self, object_type):
         self.object_type = object_type
 
+    @classmethod
+    def resolve_object_type(cls, object_type):
+        if callable(object_type) and not isclass(object_type):
+            return object_type()
+        return object_type
+
     def bind(self, selection, obj):
         super(RelatedField, self).bind(selection, obj)
+        self.object_type = self.__class__.resolve_object_type(self.object_type)
         if self.object_type == 'self':
             self.object_type = obj.__class__
-        elif callable(self.object_type) and not isclass(self.object_type):
-            self.object_type = self.object_type()
 
     def _serialize_value(self, value):
         obj_instance = self.object_type(

--- a/django_graph_api/graphql/types.py
+++ b/django_graph_api/graphql/types.py
@@ -269,8 +269,9 @@ class RelatedField(Field):
 
     def get_value(self):
         value = super(RelatedField, self).get_value()
-        if value is not None:
-            return self._serialize_value(value)
+        if value is None:
+            return None
+        return self._serialize_value(value)
 
 
 class ManyRelatedField(RelatedField):
@@ -311,6 +312,8 @@ class ManyRelatedField(RelatedField):
 
     def get_value(self):
         values = super(RelatedField, self).get_value()
+        if values is None:
+            return None
         if isinstance(values, Manager):
             values = values.all()
         return [

--- a/django_graph_api/tests/test_introspection.py
+++ b/django_graph_api/tests/test_introspection.py
@@ -1,0 +1,118 @@
+from test_app.schema import schema
+
+
+def test_introspect_types_and_fields():
+    document = '''{
+        __schema {
+            types {
+                name
+                kind
+                fields {
+                    name
+                }
+            }
+        }
+    }
+    '''
+    assert schema.execute(document) == {
+        'data': {
+            '__schema': {
+                'types': [
+                    {
+                        "name": "Character",
+                        "kind": "OBJECT",
+                        "fields": [
+                            {
+                                "name": "appears_in"
+                            },
+                            {
+                                "name": "best_friend"
+                            },
+                            {
+                                "name": "friends"
+                            },
+                            {
+                                "name": "name"
+                            },
+                        ],
+                    },
+                    {
+                        "name": "Episode",
+                        "kind": "OBJECT",
+                        "fields": [
+                            {
+                                "name": "characters"
+                            },
+                            {
+                                "name": "name"
+                            },
+                            {
+                                "name": "next"
+                            },
+                            {
+                                "name": "number"
+                            },
+                        ],
+                    },
+                    {
+                        "name": "Int",
+                        "kind": "SCALAR",
+                        "fields": None,
+                    },
+                    {
+                        "name": "String",
+                        "kind": "SCALAR",
+                        "fields": None,
+                    },
+                    {
+                        "name": "__Field",
+                        "kind": "OBJECT",
+                        "fields": [
+                            {
+                                "name": "description"
+                            },
+                            {
+                                "name": "name"
+                            },
+                            {
+                                "name": "type"
+                            },
+                        ],
+                    },
+                    {
+                        "name": "__Schema",
+                        "kind": "OBJECT",
+                        "fields": [
+                            {
+                                "name": "mutationType"
+                            },
+                            {
+                                "name": "queryType"
+                            },
+                            {
+                                "name": "types"
+                            },
+                        ],
+                    },
+                    {
+                        "name": "__Type",
+                        "kind": "OBJECT",
+                        "fields": [
+                            {
+                                "name": "description"
+                            },
+                            {
+                                "name": "fields"
+                            },
+                            {
+                                "name": "kind"
+                            },
+                            {
+                                "name": "name"
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+    }

--- a/django_graph_api/tests/test_views.py
+++ b/django_graph_api/tests/test_views.py
@@ -52,19 +52,3 @@ def test_post__csrf_required(execute):
     )
     assert response.status_code == 403
     execute.assert_not_called()
-
-
-def test_post__introspection_error():
-    query = 'query IntrospectionQuery {__schema }'
-    client = Client()
-    response = client.post(
-        '/graphql',
-        json.dumps({
-            'query': query,
-        }),
-        content_type='application/json',
-        HTTP_ACCEPT='application/json',
-    )
-    assert isinstance(response, JsonResponse)
-    assert response.status_code == 200
-    assert response.json() == {'error': 'This version of django-graph-api does not support introspection'}

--- a/django_graph_api/views.py
+++ b/django_graph_api/views.py
@@ -1,5 +1,7 @@
+from traceback import format_exc
 import json
 
+from django.conf import settings
 from django.http import JsonResponse
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
@@ -41,7 +43,14 @@ class GraphQLView(View):
             response_data = self.schema.execute(request_data['query'])
             return JsonResponse(response_data)
         except Exception as e:
-            return JsonResponse({'error': str(e)})
+            error_data = {
+                'error': str(e),
+            }
+
+            if settings.DEBUG:
+                error_data['traceback'] = format_exc().split('\n')
+
+            return JsonResponse(error_data)
 
     def get_request_data(self):
         """


### PR DESCRIPTION
This implements basic introspection. It doesn't work fully with graphiQL, because the graphiQL introspection query uses fragments, which we don't yet support. (It may also run into issues with arguments, but those are already slated for the current release.)

I believe this PR represents a complete, reasonable unit of work that could be merged as-is. Full compatibility with graphiQL is something we can circle back to later once fragments are supported.

Resolved #33.