### PR TITLE
Move from Gitter to Slack

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
-Django Graph API |travis| |gitter| |rtd|
+Django Graph API |travis| |slack| |rtd|
 ========================================
 
-.. |gitter| image:: https://badges.gitter.im/django-graph-api/Lobby.svg
-   :alt: Join the chat at https://gitter.im/django-graph-api/Lobby
-   :target: https://gitter.im/django-graph-api/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+.. |slack| image:: https://slack-djangographapi.now.sh/badge.svg
+   :alt: Join us on slack at https://slack-djangographapi.now.sh
+   :target: https://slack-djangographapi.now.sh
 .. |travis| image:: https://travis-ci.org/melinath/django-graph-api.svg?branch=master
    :alt: Build status on travis-ci
    :target: https://travis-ci.org/melinath/django-graph-api
@@ -47,9 +47,9 @@ Once your pull request is complete, one of the core contributors will review it 
 
 To run the tests, run ``pytest``.
 
-If you have any questions or want to start contributing, chat with us on gitter_.
+If you have any questions or want to start contributing, chat with us on Slack_.
 
-.. _gitter: https://gitter.im/django-graph-api/Lobby
+.. _Slack: https://slack-djangographapi.now.sh/
 
 Code of conduct
 ---------------

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -9,13 +9,13 @@ Once you're done writing code, you will need to open a pull request with your ch
 - All tests must be passing.
 - Any relevant documentation has been updated.
 
-If you need help with something, that's totally fine. Do what you can and then ask for what you need, either through your PR or on gitter_. Just be aware that there may be a delay before someone comes along who has time to provide it.
+If you need help with something, that's totally fine. Do what you can and then ask for what you need, either through your PR or on Slack_. Just be aware that there may be a delay before someone comes along who has time to provide it.
 
 Once your pull request is complete, one of the core contributors will review it and give feedback or merge as appropriate.
 
-If you have any questions or just want to discuss the project, chat with us on gitter_.
+If you have any questions or just want to discuss the project, chat with us on Slack_.
 
-.. _gitter: https://gitter.im/django-graph-api/Lobby
+.. _Slack: https://slack-djangographapi.now.sh/
 .. _Github projects: https://github.com/melinath/django-graph-api/projects
 
 Code of conduct

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,12 +3,12 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Django Graph API |travis| |gitter| |rtd|
+Django Graph API |travis| |slack| |rtd|
 ============================================
 
-.. |gitter| image:: https://badges.gitter.im/django-graph-api/Lobby.svg
-   :alt: Join the chat at https://gitter.im/django-graph-api/Lobby
-   :target: https://gitter.im/django-graph-api/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+.. |slack| image:: https://slack-djangographapi.now.sh/badge.svg
+   :alt: Join us on slack at https://slack-djangographapi.now.sh
+   :target: https://slack-djangographapi.now.sh
 .. |travis| image:: https://travis-ci.org/melinath/django-graph-api.svg?branch=master
    :alt: Build status on travis-ci
    :target: https://travis-ci.org/melinath/django-graph-api
@@ -79,14 +79,14 @@ In order to increase its usage amongst Python developers, we are trying to creat
 
 Django Graph API is still a young project and doesn't yet support many of the key GraphQL features, such as filtering and mutations. See a list of `supported and unsupported features`_.
 
-If you'd like to help contribute, read our `contributing guidelines`_ and chat with us on Gitter_.
+If you'd like to help contribute, read our `contributing guidelines`_ and chat with us on Slack_.
 
 .. _GraphQL: http://graphql.org/
 .. _official documentation: http://graphql.org/learn/
 .. _Django: https://www.djangoproject.com/
 .. _Python: https://www.python.org/
 .. _GraphQL API explorer: https://developer.github.com/v4/explorer/
-.. _Gitter: https://gitter.im/django-graph-api/Lobby
+.. _Slack: https://slack-djangographapi.now.sh/
 .. _contributing guidelines: contribute.html
 .. _supported and unsupported features: features.html
 


### PR DESCRIPTION
I used Now to host slackin (as per their suggestion).
The slack invite user has an email of django.graph.api@gmail.com.
I used my email (but probably should've used django.graph.api's email) to setup ReCaptcha.
The build url is https://slackin-xzurzebddc.now.sh/ and the alias'ed url is https://slack-djangographapi.now.sh/