### PR TITLE
Requirements from requirements.txt are needed for pytest to run. Add note for Windows users re. setting up path.

### DIFF
--- a/docs/start_developing.rst
+++ b/docs/start_developing.rst
@@ -17,6 +17,10 @@ If you are using pipenv_:
     cd django-graph-api
     pipenv install    # this will create your virtualenv and install the requirements
 
+(Note for Windows users: The py launcher cannot tell pipenv which Python version to use.
+The simplest fix is to add to your path only the desired Python folder and its Scripts subfolder,
+then use the commands as shown here without py.)
+
 Run the tests
 -------------
 
@@ -28,6 +32,7 @@ Run the tests
 
     pipenv shell
     pip install -r requirements-test.txt
+    pip install -r requirements.txt
     pytest
 
 Run the test project


### PR DESCRIPTION
pytest fails without the requirements in requirements.txt, so add the line to install them before running pytest.  It's fine to have that after requirements-text.txt.

The Windows py launcher doesn't set the Windows path, so pipenv subcommands can't find other programs they need.  After several alternate attempts, the simplest fix is just to put the desired Python and its Scripts in the path, and remove other Python versions.  This sort-of defeats the purpose of the py launcher, but this is not a problem that should be solved here -- this is a py launcher vs. pipenv issue.