### PR TITLE
add support for variables, including default values

### DIFF
--- a/django_graph_api/graphql/schema.py
+++ b/django_graph_api/graphql/schema.py
@@ -341,7 +341,7 @@ class Schema(object):
         self.query_root = QueryRoot
         return QueryRoot
 
-    def execute(self, document):
+    def execute(self, document, variables=None):
         """
         Queries the schema in python.
 
@@ -382,17 +382,26 @@ class Schema(object):
         ]
         assert len(queries) == 1, "Exactly one query must be defined"
 
+        query = queries[0]
+
         fragments = {
             definition.name: definition
             for definition in ast.definitions
             if isinstance(definition, FragmentDefinition)
         }
 
+        variable_definitions = {
+            definition.name: definition
+            for definition in query.variable_definitions
+        }
+
         return {
             'data': self.query_root(
-                ast=queries[0],
+                ast=query,
                 data=None,
                 fragments=fragments,
+                variable_definitions=variable_definitions,
+                variables=variables
             ).serialize(),
         }
 

--- a/django_graph_api/tests/test_variables.py
+++ b/django_graph_api/tests/test_variables.py
@@ -1,0 +1,86 @@
+from test_app.schema import schema
+
+
+def test_query_default_episode_and_characters(starwars_data):
+    document = '''
+        query EpisodeAndCharacters($episode: ID = 5) {
+            episode(number: $episode) {
+                name
+                number
+                characters (type: ["human", "droid"]) {
+                    name
+                }
+            }
+        }
+        '''
+    assert schema.execute(document) == {
+        'data': {
+            'episode': {
+                'name': 'The Empire Strikes Back',
+                'number': 5,
+                'characters': [
+                    {'name': 'Luke Skywalker'},
+                    {'name': 'Darth Vader'},
+                    {'name': 'Han Solo'},
+                    {'name': 'Leia Organa'},
+                    {'name': 'C-3PO'},
+                    {'name': 'R2-D2'},
+                ]
+            },
+        }
+    }
+
+
+def test_query_missing_variable_no_default(starwars_data):
+    document = '''
+        query Episodes($episode: Int) {
+            episodes(number: $episode) {
+                number
+            }
+        }
+        '''
+    assert schema.execute(document) == {
+        'data': {
+            'episodes': [{
+                'number': 4
+            }, {
+                'number': 5
+            }]
+        }
+    }
+
+
+def test_query_episodes_and_droids(starwars_data):
+    document = '''
+        query EpisodesAndCharacterType($type: String) {
+            episodes {
+                name
+                number
+                characters (types: $type) {
+                    name
+                }
+            }
+        }
+        '''
+    assert schema.execute(document, {"type": "droid"}) == {
+        'data': {
+            'episodes': [
+                {
+                    'name': 'A New Hope',
+                    'number': 4,
+                    'characters': [
+                        {'name': 'C-3PO'},
+                        {'name': 'R2-D2'},
+                    ]
+                },
+                {
+                    'name': 'The Empire Strikes Back',
+                    'number': 5,
+                    'characters': [
+                        {'name': 'C-3PO'},
+                        {'name': 'R2-D2'},
+                    ]
+                },
+            ]
+        }
+    }

--- a/django_graph_api/tests/test_views.py
+++ b/django_graph_api/tests/test_views.py
@@ -33,7 +33,28 @@ def test_post_request_executed(execute):
     assert isinstance(response, JsonResponse)
     assert response.status_code == 200
     assert response.content == b'{}'
-    execute.assert_called_once_with(query)
+    execute.assert_called_once_with(query, None)
+
+@mock.patch('test_project.urls.schema.execute')
+def test_variables_sent_in_post(execute):
+    execute.return_value = {}
+    query = 'this is totally a query'
+    client = Client()
+    response = client.post(
+        '/graphql',
+        json.dumps({
+            'query': query,
+            'variables': {
+                'level': 9001
+            }
+        }),
+        content_type='application/json',
+        HTTP_ACCEPT='application/json',
+    )
+    assert isinstance(response, JsonResponse)
+    assert response.status_code == 200
+    assert response.content == b'{}'
+    execute.assert_called_once_with(query, {'level': 9001})
 
 
 def test_post_request_with_error():

--- a/django_graph_api/tests/test_views.py
+++ b/django_graph_api/tests/test_views.py
@@ -35,6 +35,7 @@ def test_post_request_executed(execute):
     assert response.content == b'{}'
     execute.assert_called_once_with(query, None)
 
+
 @mock.patch('test_project.urls.schema.execute')
 def test_variables_sent_in_post(execute):
     execute.return_value = {}

--- a/django_graph_api/views.py
+++ b/django_graph_api/views.py
@@ -18,7 +18,7 @@ class GraphQLView(View):
 
     ``GET`` returns the HTML for the GraphiQL API explorer.
 
-    ``POST`` accepts a body in the form of ``{'query': query, 'variables': null}`` and returns a JSON response with
+    ``POST`` accepts a body in the form of ``{'query': query, 'variables': variables}`` and returns a JSON response with
     either a "data" or "error" object.
     """
     graphiql_version = '0.11.11'
@@ -44,7 +44,7 @@ class GraphQLView(View):
     def post(self, request, *args, **kwargs):
         try:
             request_data = self.get_request_data()
-            response_data = self.schema.execute(request_data['query'])
+            response_data = self.schema.execute(request_data['query'], request_data.get('variables'))
             return JsonResponse(response_data)
         except Exception as e:
             error_data = {


### PR DESCRIPTION
Notable omission: there is no support for explicitly null default values, due to lack of support for differentiating that from a missing default value in the upstream AST library.  See #80. 

Closes #59.