### PR TITLE
Add Django 1.8 to CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 env:
+- DJANGO=1.8.18
 - DJANGO=1.11.9
 - DJANGO=2.0.1
 python:


### PR DESCRIPTION
This commit will ensure that Django 1.8.18 is one of the Django
versions tested by the Travis CI system