### PR TITLE
Added requirements file for readthedocs

### DIFF
--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -1,0 +1,5 @@
+# Requirements for readthedocs until they add pipfile support
+django==1.11.4
+graphql-py==0.6
+ply==3.10
+pytz==2017.2


### PR DESCRIPTION
Called it rtd-requirements so that hopefully people won't get confused by it. This required updating a setting on the rtd side.

Unfortunately, we can't just rely on setup.py install because requirements need to be installed before setup.py can be run (because `__init__.py` provides import shortcuts).

Fixes #91.