### PR TITLE
57 non null fields

### DIFF
--- a/django_graph_api/graphql/schema.py
+++ b/django_graph_api/graphql/schema.py
@@ -175,9 +175,9 @@ class FieldObject(Object):
             type_ = field.object_type
             if isinstance(field.type_, List):
                 type_ = List(type_)
-            elif not field.nullable:
+            elif not field.null:
                 type_ = NonNull(type_)
-        elif not field.nullable:
+        elif not field.null:
             type_ = NonNull(field.type_)
         else:
             type_ = field.type_

--- a/django_graph_api/graphql/schema.py
+++ b/django_graph_api/graphql/schema.py
@@ -24,7 +24,8 @@ from django_graph_api.graphql.types import (
     SCALAR,
     String,
     UNION,
-    NonNull)
+    NonNull,
+)
 from django_graph_api.graphql.utils import (
     format_error,
     GraphQLError

--- a/django_graph_api/tests/graphql/test_types.py
+++ b/django_graph_api/tests/graphql/test_types.py
@@ -13,7 +13,8 @@ from django_graph_api.graphql.types import (
     Int,
     List,
     String,
-    IntegerField)
+    IntegerField,
+)
 from django_graph_api.graphql.utils import GraphQLError
 
 

--- a/django_graph_api/tests/graphql/test_types.py
+++ b/django_graph_api/tests/graphql/test_types.py
@@ -81,7 +81,7 @@ def test_get_value_non_null():
     field.bind(selection, obj)
 
     with pytest.raises(GraphQLError):
-        field.value
+        field.get_value()
 
 
 def test_int_coerce_result():

--- a/django_graph_api/tests/test_introspection.py
+++ b/django_graph_api/tests/test_introspection.py
@@ -18,7 +18,7 @@ from django_graph_api.graphql.types import (
     ManyRelatedField,
     RelatedField,
     String,
-)
+    NonNull)
 
 from test_app.schema import (
     Character,
@@ -77,6 +77,36 @@ def test_type__scalar__get_enumValues():
 def test_type__scalar__get_ofType():
     type_object = TypeObject(None, Boolean, None)
     assert type_object.get_ofType() is None
+
+
+def test_type__non_null__get_fields():
+    type_object = TypeObject(None, NonNull(Boolean), None)
+    assert type_object.get_fields() is None
+
+
+def test_type__non_null__get_inputFields():
+    type_object = TypeObject(None, NonNull(Boolean), None)
+    assert type_object.get_inputFields() is None
+
+
+def test_type__non_null__get_interfaces():
+    type_object = TypeObject(None, NonNull(Boolean), None)
+    assert type_object.get_interfaces() is None
+
+
+def test_type__non_null__get_possibleTypes():
+    type_object = TypeObject(None, NonNull(Boolean), None)
+    assert type_object.get_possibleTypes() is None
+
+
+def test_type__non_null__get_enumValues():
+    type_object = TypeObject(None, NonNull(Boolean), None)
+    assert type_object.get_enumValues() is None
+
+
+def test_type__non_null__get_ofType():
+    type_object = TypeObject(None, NonNull(Boolean), None)
+    assert type_object.get_ofType() is Boolean
 
 
 def test_type__object__get_name():
@@ -301,6 +331,14 @@ def test_execute__filter_type():
             kind
             fields {
                 name
+                type {
+                    name
+                    kind
+                    ofType {
+                        name
+                        kind
+                    }
+                }
             }
         }
     }
@@ -311,11 +349,55 @@ def test_execute__filter_type():
                 'name': 'Character',
                 'kind': 'OBJECT',
                 'fields': [
-                    {'name': 'appears_in'},
-                    {'name': 'best_friend'},
-                    {'name': 'friends'},
-                    {'name': 'id'},
-                    {'name': 'name'},
+                    {
+                        'name': 'appears_in',
+                        'type': {
+                            'name': None,
+                            'kind': 'LIST',
+                            'ofType': {
+                                'name': 'Episode',
+                                'kind': 'OBJECT'
+                            }
+                        },
+                    },
+                    {
+                        'name': 'best_friend',
+                        'type': {
+                            'name': 'Character',
+                            'kind': 'OBJECT',
+                            'ofType': None
+                        },
+                    },
+                    {
+                        'name': 'friends',
+                        'type': {
+                            'name': None,
+                            'kind': 'LIST',
+                            'ofType': {
+                                'name': 'Character',
+                                'kind': 'OBJECT'
+                            }
+                        },
+                    },
+                    {
+                        'name': 'id',
+                        'type': {
+                            'name': None,
+                            'kind': 'NON_NULL',
+                            'ofType': {
+                                'name': 'Int',
+                                'kind': 'SCALAR'
+                            }
+                        },
+                    },
+                    {
+                        'name': 'name',
+                        'type': {
+                            'name': 'String',
+                            'kind': 'SCALAR',
+                            'ofType': None
+                        },
+                    },
                 ],
             }
         }

--- a/django_graph_api/tests/test_introspection.py
+++ b/django_graph_api/tests/test_introspection.py
@@ -18,7 +18,8 @@ from django_graph_api.graphql.types import (
     ManyRelatedField,
     RelatedField,
     String,
-    NonNull)
+    NonNull,
+)
 
 from test_app.schema import (
     Character,

--- a/test_app/schema.py
+++ b/test_app/schema.py
@@ -46,7 +46,7 @@ class Episode(Object):
 
 
 class Character(Object):
-    id = IntegerField()
+    id = IntegerField(null=False)
     name = CharField()
     friends = ManyRelatedField('self')
     best_friend = RelatedField('self')
@@ -58,9 +58,9 @@ class Character(Object):
 
 @schema.register_query_root
 class QueryRoot(Object):
-    hero = RelatedField(Character)
+    hero = RelatedField(Character, null=False)
     episodes = ManyRelatedField(Episode)
-    episode = RelatedField(Episode, arguments={'number': Int()})
+    episode = RelatedField(Episode, arguments={'number': Int()}, null=False)
 
     def get_hero(self):
         return CharacterModel.objects.get(name='R2-D2')


### PR DESCRIPTION
- Use `Field(null=False)` to mark a field as non-nullable
- If that field returns None, throw a field error
- In introspection, return NON_NULL as the type's kind, and ofType returns the original type

Issues:
- What do we do about `ManyRelatedField(null=False)`?
  - [ ] Must return a list with no null elements, but can return null
  - [x] Must not return null, but can return an empty list or a list with null elements
  - [ ] Don't worry about it for now
- The only difference in the response between a field that returns `None` that is nullable and one that is not is that an error in the `errors` list is added to say that was not allowed. But if someone is not expecting that field to be null then tries to use the result without checking for errors, they will have problems. We also don't currently have a way of showing which error was for which field.
  - [x] This is okay since it aligns with the specs
  - [ ] We should handle these a different way

Fixes #57 